### PR TITLE
[16.0][FIX] sale_channel_search_engine: Add to index

### DIFF
--- a/sale_channel_search_engine/models/se_indexable_record.py
+++ b/sale_channel_search_engine/models/se_indexable_record.py
@@ -28,5 +28,6 @@ class SEIndexableRecord(models.AbstractModel):
             indexes = channel.search_engine_id.index_ids.filtered(
                 lambda s: s.model_id.model == self._name
             )
-            bindings |= items._add_to_index(indexes)
+            if indexes:
+                bindings |= items._add_to_index(indexes)
         (existing_bindings - bindings).write({"state": "to_delete"})


### PR DESCRIPTION
reopen https://github.com/OCA/sale-channel/pull/16

-------------------------

This is unnecessary to call `_add_to_index()` if we don't find indexes where the records should be added to.

This has a side effect:
`_add_to_index()` returns the bindings of the record, if no `indexes` is passed as argument to `_add_to_index()`, it does so for all the indexes.

Now imagine:
1. Create 2 sale channels: `Channel A` linked to an index, `Channel B` not linked to any index.
2. Add a product to both sale channels => A binding is created for this product as it is linked to `Channel A`.
3. Remove the product from `Channel A` => `_synchronize_channel_index()` is triggered on the product.
4. `_add_to_index(None)` will be called for `Channel B` => `_add_to_index(None)` will return all the bindings of the product, including the binding created by the link with `Channel A`.
5. This binding will not be marked 'to_delete' as we mark 'to_delete' the bindings not returned by `_add_to_index()`.