### PR TITLE
[FIX] sale_channel_search_engine_category: fix missing se.index when setting the search_engine_id

### DIFF
--- a/sale_channel_search_engine_category/models/__init__.py
+++ b/sale_channel_search_engine_category/models/__init__.py
@@ -1,1 +1,2 @@
 from . import product_category
+from . import sale_channel

--- a/sale_channel_search_engine_category/models/sale_channel.py
+++ b/sale_channel_search_engine_category/models/sale_channel.py
@@ -1,0 +1,18 @@
+# Copyright 2025 Akretion (https://www.akretion.com).
+# @author Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class SaleChannel(models.Model):
+    _inherit = "sale.channel"
+
+    def write(self, vals):
+        res = super().write(vals)
+        if "search_engine_id" in vals:
+            categs = self.root_categ_ids
+            while categs:
+                categs._synchronize_channel_index()
+                categs = categs.child_id
+        return res

--- a/sale_channel_search_engine_category/tests/test_channel.py
+++ b/sale_channel_search_engine_category/tests/test_channel.py
@@ -149,3 +149,36 @@ class TestChannel(TestBindingIndexBaseFake):
             self.assertEqual(
                 set(bindings.mapped("state")), {"to_recompute", "to_delete"}
             )
+
+    def test_remove_index(self):
+        self.channel_2.search_engine_id = None
+        # Categ are still linked to the channel
+        self.assertEqual(
+            self.categ_level_1.channel_ids, self.channel_1 | self.channel_2
+        )
+        self.assertEqual(
+            self.categ_level_2.channel_ids, self.channel_1 | self.channel_2
+        )
+        # But index binding are removed
+        for categ in [self.categ_root, self.categ_level_1, self.categ_level_2]:
+            bindings = categ._get_bindings()
+            self.assertEqual(len(bindings), 2)
+            self.assertEqual(
+                set(bindings.mapped("state")), {"to_recompute", "to_delete"}
+            )
+
+    def test_remove_and_add_index(self):
+        se = self.channel_2.search_engine_id
+        self.channel_2.search_engine_id = None
+        self.channel_2.search_engine_id = se
+        self.assertEqual(
+            self.categ_level_1.channel_ids, self.channel_1 | self.channel_2
+        )
+        self.assertEqual(
+            self.categ_level_2.channel_ids, self.channel_1 | self.channel_2
+        )
+
+        for categ in [self.categ_root, self.categ_level_1, self.categ_level_2]:
+            bindings = categ._get_bindings()
+            self.assertEqual(len(bindings), 2)
+            self.assertEqual(set(bindings.mapped("state")), {"to_recompute"})


### PR DESCRIPTION
When you create a sale channel, set the root_categ_ids and then you set the search_engine_id, the binding where missing.

Fix this use case