### PR TITLE
[18.0][FIX] sale_channel_partner: fix sale_channel view 

### DIFF
--- a/sale_channel_partner/README.rst
+++ b/sale_channel_partner/README.rst
@@ -58,15 +58,15 @@ Authors
 Contributors
 ------------
 
--  Kevin Khao <kevin.khao@akretion.com>
--  Sébastien Beau <sebastien.beau@akretion.com>
+- Kevin Khao <kevin.khao@akretion.com>
+- Sébastien Beau <sebastien.beau@akretion.com>
 
 Other credits
 -------------
 
 The development of this module has been financially supported by:
 
--  Akretion <`www.akretion.com\\> <http://www.akretion.com\>>`__
+- Akretion <`www.akretion.com\\> <http://www.akretion.com\>>`__
 
 Maintainers
 -----------

--- a/sale_channel_partner/models/sale_channel.py
+++ b/sale_channel_partner/models/sale_channel.py
@@ -19,14 +19,14 @@ class SaleChannel(models.Model):
     )
 
     def button_open_bindings(self):
-        tree_view_id = self.env.ref(
+        list_view_id = self.env.ref(
             "sale_channel_partner.sale_channel_partner_view_tree"
         ).id
         act = {
             "name": _("Partner bindings"),
             "res_model": "sale.channel.partner",
             "type": "ir.actions.act_window",
-            "views": [(tree_view_id, "tree")],
+            "views": [(list_view_id, "list")],
             "domain": [("sale_channel_id", "=", self.id)],
         }
         return act

--- a/sale_channel_partner/views/sale_channel_view.xml
+++ b/sale_channel_partner/views/sale_channel_view.xml
@@ -5,17 +5,15 @@
         <field name="model">sale.channel</field>
         <field name="inherit_id" ref="sale_channel.sale_channel_view_form" />
         <field name="arch" type="xml">
-            <xpath expr="//h1" position="before">
-                <div class="oe_button_box" name="button_box">
-                    <button
-                        name="button_open_bindings"
-                        type="object"
-                        class="oe_stat_button"
-                        icon="fa-link"
-                    >
-                        <field name="count_sale_channel_partners" widget="statinfo" />
-                    </button>
-                </div>
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button
+                    name="button_open_bindings"
+                    type="object"
+                    class="oe_stat_button"
+                    icon="fa-link"
+                >
+                    <field name="count_sale_channel_partners" widget="statinfo" />
+                </button>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
the button_open_bindings button was misplaced and the related action was not fully migrated